### PR TITLE
Explicitly make field empty to prevent TF from detecting change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,13 +42,13 @@ resource "azurerm_monitor_action_group" "action" {
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "main" {
   for_each = var.scheduled_query_alert_rules
-
-  name                = "${each.key}-queryrule"
-  description         = each.value.description
-  resource_group_name = azurerm_resource_group.main.name
-  location            = var.location
-  tags                = var.tags
-  enabled             = true
+  authorized_resource_ids = []
+  name                    = "${each.key}-queryrule"
+  description             = each.value.description
+  resource_group_name     = azurerm_resource_group.main.name
+  location                = var.location
+  tags                    = var.tags
+  enabled                 = true
 
   trigger {
     operator  = each.value.criteria.operator


### PR DESCRIPTION
Terraform wrongfully detects this field as having changed when left unset. E.g:
```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # azurerm_monitor_scheduled_query_rules_alert.main["example"] has been changed
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "main" {
      + authorized_resource_ids = []
        id                      = "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/resourceGroups/my-rg/providers/Microsoft.Insights/scheduledQueryRules/my-queryrule"
        name                    = "my-queryrule"
        # (12 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```